### PR TITLE
Reverse Camera controls

### DIFF
--- a/src/engine/Camera.cpp
+++ b/src/engine/Camera.cpp
@@ -42,16 +42,36 @@ void Camera::update(set<SDL_Scancode> pressedKeys, Controller::JoystickState cur
 
             if (pressedKeys.find(SDL_SCANCODE_A) != pressedKeys.end())
             {
-                if(xDiff <= minDistWidth)
+                if(reversed)
                 {
-                    scene->position.x += velocity;
+                    if(xTotal <= minDistWidth + 100)
+                    {
+                        scene->position.x -= velocity;
+                    }
+                }
+                else
+                {
+                    if(xDiff <= minDistWidth)
+                    {
+                        scene->position.x += velocity;
+                    }
                 }
             }
             if (pressedKeys.find(SDL_SCANCODE_D) != pressedKeys.end())
             {
-                if (xTotal <= minDistWidth + 100)
+                if(reversed)
                 {
-                    scene->position.x -= velocity;
+                    if(xDiff <= minDistWidth)
+                    {
+                        scene->position.x += velocity;
+                    }
+                }
+                else
+                {
+                    if(xTotal <= minDistWidth + 100)
+                    {
+                        scene->position.x -= velocity;
+                    }
                 }
             }
 

--- a/src/engine/Camera.cpp
+++ b/src/engine/Camera.cpp
@@ -67,7 +67,7 @@ void Camera::update(set<SDL_Scancode> pressedKeys, Controller::JoystickState cur
             }
             if (pressedKeys.find(SDL_SCANCODE_S) != pressedKeys.end())
             {
-                if (yTotal <= minDistHeight + 250)
+                if (yTotal <= minDistHeight + 200)
                 {
                     scene->position.y -= velocity;
                 }

--- a/src/engine/Camera.cpp
+++ b/src/engine/Camera.cpp
@@ -29,12 +29,13 @@ void Camera::update(set<SDL_Scancode> pressedKeys, Controller::JoystickState cur
         if( this->ghost != NULL )
         {
             float velocity = this->ghost->movespeed;
+            bool reversed = this->ghost->reverse_controls;
             int windowWidth = 1000;
             int windowHeight = 1000;
             // int minDistWidth = windowWidth / 2;
             // int minDistHeight = windowHeight / 2;
-            int minDistWidth = 250;
-            int minDistHeight = 250;
+            int minDistWidth = 100;
+            int minDistHeight = 100;
 
             int xDiff = abs(abs(scene->position.x)-abs(this->ghost->position.x));
             int xTotal = abs(abs(scene->position.x + this->ghost->position.x) - windowWidth);
@@ -48,7 +49,7 @@ void Camera::update(set<SDL_Scancode> pressedKeys, Controller::JoystickState cur
             }
             if (pressedKeys.find(SDL_SCANCODE_D) != pressedKeys.end())
             {
-                if (xTotal <= minDistWidth + 50)
+                if (xTotal <= minDistWidth + 100)
                 {
                     scene->position.x -= velocity;
                 }
@@ -66,7 +67,7 @@ void Camera::update(set<SDL_Scancode> pressedKeys, Controller::JoystickState cur
             }
             if (pressedKeys.find(SDL_SCANCODE_S) != pressedKeys.end())
             {
-                if (yTotal <= minDistHeight + 100)
+                if (yTotal <= minDistHeight + 250)
                 {
                     scene->position.y -= velocity;
                 }

--- a/src/engine/Camera.cpp
+++ b/src/engine/Camera.cpp
@@ -80,16 +80,36 @@ void Camera::update(set<SDL_Scancode> pressedKeys, Controller::JoystickState cur
             
             if (pressedKeys.find(SDL_SCANCODE_W) != pressedKeys.end())
             {
-                if(yDiff <= minDistHeight)
+                if(reversed)
                 {
-                    scene->position.y += velocity;
+                    if(yTotal <= minDistHeight + 200)
+                    {
+                        scene->position.y -= velocity;
+                    }
+                }
+                else
+                {
+                    if(yDiff <= minDistHeight)
+                    {
+                        scene->position.y += velocity;
+                    }
                 }
             }
             if (pressedKeys.find(SDL_SCANCODE_S) != pressedKeys.end())
             {
-                if (yTotal <= minDistHeight + 200)
+                if(reversed)
                 {
-                    scene->position.y -= velocity;
+                    if(yDiff <= minDistHeight)
+                    {
+                        scene->position.y += velocity;
+                    }
+                }
+                else
+                {
+                    if (yTotal <= minDistHeight + 200)
+                    {
+                        scene->position.y -= velocity;
+                    }
                 }
             }
         }

--- a/src/engine/Camera.cpp
+++ b/src/engine/Camera.cpp
@@ -55,7 +55,7 @@ void Camera::update(set<SDL_Scancode> pressedKeys, Controller::JoystickState cur
                 }
             }
 
-            int yDiff = abs(abs(scene->position.y)-abs(this->ghost->position.y));
+            int yDiff = abs(scene->position.y + this->ghost->position.y);
             int yTotal = abs(abs(scene->position.y + this->ghost->position.y) - windowHeight);
             
             if (pressedKeys.find(SDL_SCANCODE_W) != pressedKeys.end())

--- a/src/engine/Camera.cpp
+++ b/src/engine/Camera.cpp
@@ -37,7 +37,7 @@ void Camera::update(set<SDL_Scancode> pressedKeys, Controller::JoystickState cur
             int minDistWidth = 100;
             int minDistHeight = 100;
 
-            int xDiff = abs(abs(scene->position.x)-abs(this->ghost->position.x));
+            int xDiff = abs(scene->position.x + this->ghost->position.x);
             int xTotal = abs(abs(scene->position.x + this->ghost->position.x) - windowWidth);
 
             if (pressedKeys.find(SDL_SCANCODE_A) != pressedKeys.end())


### PR DESCRIPTION
# What I did
- camera controls now reverse when the ghost gets hit with the snake boss waves
- fixed x-axis and y-axis camera movement bugs when the scene `position` and ghost `position` were both positive (undefined behavior now addressed)